### PR TITLE
BUG: Remove hostname from vbox bootstrapper

### DIFF
--- a/bin/01_ubuntu_common.sh
+++ b/bin/01_ubuntu_common.sh
@@ -5,8 +5,6 @@ sudo apt-get update -q -y
 sudo apt-get upgrade -y
 sudo apt-get install wget -y
 
-sudo hostnamectl set-hostname $HOSTNAME
-
 sudo groupadd vboxsf
 sudo su -c "useradd qiime2 -s /bin/bash -m -G sudo,vboxsf"
 echo qiime2:qiime2 | sudo chpasswd

--- a/bin/02_aws.sh
+++ b/bin/02_aws.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# NOTE: We don't set up the hostname on AWS, because dynamic hostnames are
+# a thing on AWS that we don't want to mess with:
+# https://stackoverflow.com/a/12900022/313548
 sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 sudo tee /etc/update-motd.d/00-header <<EOF

--- a/bin/02_vbox.sh
+++ b/bin/02_vbox.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Hostname setup
+sudo hostnamectl set-hostname $HOSTNAME
+sudo hostname $HOSTNAME
+sudo sed -i 's/127.0.1.1.*/127.0.1.1\t'"$HOSTNAME"'/g' /etc/hosts
+
 # Install Guest Additions
 cd /tmp
 sudo mkdir /tmp/isomount

--- a/packer_vars/vbox-bootstrap.json
+++ b/packer_vars/vbox-bootstrap.json
@@ -34,7 +34,7 @@
         "/install/vmlinuz noapic<wait>",
         " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
         " auto<wait>",
-        " hostname={{ user `HOSTNAME` }}<wait>",
+        " hostname=placeholder<wait>",
         " fb=false<wait>",
         " debconf/frontend=noninteractive<wait>",
         " debian-installer=en_US<wait>",


### PR DESCRIPTION
Fixes #35

Also, we stop attempting to set the hostname on AWS images here.