### PR TITLE
MAINT: VirtualBox target update to Ubuntu 16.04.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - Packer
 - AWS Account
+- VirtualBox (latest version)
 
 ### Version Bumping
 
@@ -34,7 +35,9 @@ $ docker push qiime2/core
 ```bash
 # Build the Virtualbox machine locally
 $ make vbox
-# Once done, upload the VMDK file to distribution server
+# Once done, zip the VMDK and OVF files, and upload to distribution server.
+# Match the naming conventions of previous releases for the zip file, its
+# extracted directory, and archive members.
 ```
 
 ### Amazon AWS AMI

--- a/packer_vars/vbox-bootstrap.json
+++ b/packer_vars/vbox-bootstrap.json
@@ -6,9 +6,9 @@
       "vm_name": "QIIME_2_BASE_IMAGE",
       "headless": false,
       "iso_urls": [
-        "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso"
+        "http://releases.ubuntu.com/16.04/ubuntu-16.04.3-server-amd64.iso"
       ],
-      "iso_checksum": "2bce60d18248df9980612619ff0b34e6",
+      "iso_checksum": "10fcd20619dce11fe094e960c85ba4a9",
       "iso_checksum_type": "md5",
       "http_directory" : "http",
       "disk_size" : 1000000,


### PR DESCRIPTION
16.04.2 URL was taken down and migrated to old-releases.ubuntu.com.