### PR TITLE
ENH: Stop forcing docker to run as root

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,14 @@ FROM continuumio/miniconda3
 
 ARG QIIME2_RELEASE
 
+ENV PATH /opt/conda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 ENV MPLBACKEND agg
+ENV HOME /home/qiime2
+
+RUN mkdir /home/qiime2
+WORKDIR /home/qiime2
 
 RUN conda update -q -y conda
 RUN conda install -q -y wget
@@ -12,10 +17,11 @@ RUN wget https://data.qiime2.org/distro/core/qiime2-${QIIME2_RELEASE}-py35-linux
 RUN conda env create -n qiime2-${QIIME2_RELEASE} --file qiime2-${QIIME2_RELEASE}-py35-linux-conda.yml
 RUN rm qiime2-${QIIME2_RELEASE}-py35-linux-conda.yml
 RUN /bin/bash -c "source activate qiime2-${QIIME2_RELEASE}"
-ENV PATH /opt/conda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH
 RUN qiime dev refresh-cache
 RUN echo "source activate qiime2-${QIIME2_RELEASE}" >> $HOME/.bashrc
 RUN echo "source tab-qiime" >> $HOME/.bashrc
 
+# TODO: update this to point at the new homedir defined above. Keeping this
+# for now because this will require an update to the user docs.
 VOLUME ["/data"]
 WORKDIR /data


### PR DESCRIPTION
Fixes #49 

---

## Test 1: File permissions

### Confirm old image runs as root

```bash
$ sudo docker run -it -v $(pwd):/data qiime2/core:2018.4 qiime \
  metadata tabulate \
    --m-input-file stats-dada2.qza \
    --o-visualization stats-dada2.qzv
Saved Visualization to: stats-dada2.qzv
$ ls -lah stats*
-rw-rw-r-- 1 powertrip powertrip  13K Jun 22 14:39 stats-dada2.qza
-rw-r--r-- 1 root      root      1.2M Jun 28 17:30 stats-dada2.qzv
```

The file saved is owned by `root/root`. Bummer.

### Confirm old image fails to work when run as current user

```bash
$ sudo docker run -it -u $(id -u):$(id -g) -v $(pwd):/data qiime2/core:2018.4 qiime \
  metadata tabulate \
    --m-input-file stats-dada2.qza \
    --o-visualization stats-dada2.qzv
Traceback (most recent call last):
  File "/opt/conda/envs/qiime2-2018.4/bin/qiime", line 11, in <module>
    sys.exit(qiime())
  File "/opt/conda/envs/qiime2-2018.4/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/opt/conda/envs/qiime2-2018.4/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/opt/conda/envs/qiime2-2018.4/lib/python3.5/site-packages/click/core.py", line 1061, in invoke
    cmd_name, cmd, args = self.resolve_command(ctx, args)
  File "/opt/conda/envs/qiime2-2018.4/lib/python3.5/site-packages/click/core.py", line 1100, in resolve_command
    cmd = self.get_command(ctx, cmd_name)
  File "/opt/conda/envs/qiime2-2018.4/lib/python3.5/site-packages/q2cli/commands.py", line 99, in get_command
    plugin = self._plugin_lookup[name]
  File "/opt/conda/envs/qiime2-2018.4/lib/python3.5/site-packages/q2cli/commands.py", line 75, in _plugin_lookup
    import q2cli.cache
  File "/opt/conda/envs/qiime2-2018.4/lib/python3.5/site-packages/q2cli/cache.py", line 301, in <module>
    CACHE = DeploymentCache()
  File "/opt/conda/envs/qiime2-2018.4/lib/python3.5/site-packages/q2cli/cache.py", line 58, in __init__
    self._cache_dir = self._get_cache_dir()
  File "/opt/conda/envs/qiime2-2018.4/lib/python3.5/site-packages/q2cli/cache.py", line 85, in _get_cache_dir
    os.makedirs(cache_dir, exist_ok=True)
  File "/opt/conda/envs/qiime2-2018.4/lib/python3.5/os.py", line 231, in makedirs
    makedirs(head, mode, exist_ok)
  File "/opt/conda/envs/qiime2-2018.4/lib/python3.5/os.py", line 231, in makedirs
    makedirs(head, mode, exist_ok)
  File "/opt/conda/envs/qiime2-2018.4/lib/python3.5/os.py", line 241, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/.config'
```

It explodes. Bummer.


### Test out the image proposed in this PR

```bash
$ sudo docker run -it -u $(id -u):$(id -g) -v $(pwd):/data qiime2/core:2018.6 qiime \
  metadata tabulate \
    --m-input-file stats-dada2.qza \
    --o-visualization stats-dada2.qzv
Saved Visualization to: stats-dada2.qzv
$ ls -lah stats*
-rw-rw-r-- 1 powertrip powertrip  13K Jun 22 14:39 stats-dada2.qza
-rw-r--r-- 1 powertrip powertrip 1.2M Jun 28 17:35 stats-dada2.qzv
```

The file saved is owned by `powertrip/powertrip`. Not a bummer! 🎉 

---

## Test 2: Process inspection

The second set of tests I would like to run, but don't have an environment available to test in ATM, is to check the running process info. I need an environment where docker does not require elevated permissions just to run (my test env requires sudo). I am fairly confident that the changes here work, but if someone was able to help test this other part, that would be awesome. I think a test could look like this:

```bash
$ sudo docker run -d qiime2/core:2018.6 sleep infinity
$ ps aux | grep sleep
```

Then, take a look at the process owner - it should be the calling user, instead of `root`.