### PR TITLE
Improve cwltool compatibility of Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ ARG QIIME2_RELEASE
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 ENV MPLBACKEND agg
+ENV XDG_CONFIG_HOME /qiime2_cache
 
 RUN conda update -q -y conda
 RUN conda install -q -y wget


### PR DESCRIPTION
This change sets `XDG_CONFIG_HOME` environment variable in the docker file.

This change is to improve the compatibility of the qiime 2 docker
image when used with the CWL reference runner(cwltool):
https://github.com/common-workflow-language/cwltool

The `XDG_CONFIG_HOME` environment variable is used by the 
click module to determine an app directory. Qiime2 uses this app 
directory to create the qiime2 cache directory. When the qiime2 
docker image is built it populates the cache: `qiime dev refresh-cache`. 
This change will allow use of this cached data by cwltool.

The CWL reference runner tries to run docker in a clean enviroment.
Part of this includes running as user 502:20.
One simple change you can see is the following command no longer fails:
docker run --user 502:20 -it qiime2/core:2018.6 qiime info

When used with cwltool/docker the image works fine but recreates the qiime2 cache each time a qiime2 is run. Each time it does so it prints:
```
QIIME is caching your current deployment for improved performance. This may take a few 
moments and should only happen once per deployment.
```

See https://forum.qiime2.org/t/qiime-docker-image-always-caching-when-used-with-cwltool/4919