### PR TITLE
Add procps to make docker container fully compatible with nextflow

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /home/qiime2
 
 RUN conda update -q -y conda
 RUN conda install -q -y wget
+RUN apt-get install -y procps
 RUN wget https://data.qiime2.org/distro/core/qiime2-${QIIME2_RELEASE}-py36-linux-conda.yml
 RUN conda env create -n qiime2-${QIIME2_RELEASE} --file qiime2-${QIIME2_RELEASE}-py36-linux-conda.yml
 RUN rm qiime2-${QIIME2_RELEASE}-py36-linux-conda.yml


### PR DESCRIPTION
This is to make the docker container fully compatible with Nextflow. `Command 'ps' required by nextflow to collect task metrics cannot be found`. Nextflow requires `ps` to be installed for [metrics/trace/report generation](https://github.com/nextflow-io/nextflow/issues/1825) in addition to [a few other tools](https://www.nextflow.io/docs/latest/tracing.html#tasks). 

More details in the [qiime2 forum](https://forum.qiime2.org/t/docker-container-not-fully-compatible-with-nextflow/18699).

I would be glad if you could add that to the v2021.2 already.