### PR TITLE
MAINT: install q2studio deps via conda, instead of apt

### DIFF
--- a/bin/01_ubuntu_common.sh
+++ b/bin/01_ubuntu_common.sh
@@ -30,6 +30,7 @@ sudo -E su -p -l qiime2 <<'EOF'
   conda update -q -y -n base conda
   wget https://data.qiime2.org/distro/core/qiime2-${QIIME2_RELEASE}-py36-linux-conda.yml
   conda env create -n qiime2-${QIIME2_RELEASE} --file qiime2-${QIIME2_RELEASE}-py36-linux-conda.yml
+  conda install -n qiime2-${QIIME2_RELEASE} gevent nodejs
   rm qiime2-${QIIME2_RELEASE}-py36-linux-conda.yml
   source activate qiime2-${QIIME2_RELEASE}
   qiime dev refresh-cache

--- a/bin/01_ubuntu_common.sh
+++ b/bin/01_ubuntu_common.sh
@@ -30,7 +30,6 @@ sudo -E su -p -l qiime2 <<'EOF'
   conda update -q -y -n base conda
   wget https://data.qiime2.org/distro/core/qiime2-${QIIME2_RELEASE}-py36-linux-conda.yml
   conda env create -n qiime2-${QIIME2_RELEASE} --file qiime2-${QIIME2_RELEASE}-py36-linux-conda.yml
-  conda install -y -n qiime2-${QIIME2_RELEASE} gevent nodejs
   rm qiime2-${QIIME2_RELEASE}-py36-linux-conda.yml
   source activate qiime2-${QIIME2_RELEASE}
   qiime dev refresh-cache

--- a/bin/01_ubuntu_common.sh
+++ b/bin/01_ubuntu_common.sh
@@ -30,7 +30,7 @@ sudo -E su -p -l qiime2 <<'EOF'
   conda update -q -y -n base conda
   wget https://data.qiime2.org/distro/core/qiime2-${QIIME2_RELEASE}-py36-linux-conda.yml
   conda env create -n qiime2-${QIIME2_RELEASE} --file qiime2-${QIIME2_RELEASE}-py36-linux-conda.yml
-  conda install -n qiime2-${QIIME2_RELEASE} gevent nodejs
+  conda install -y -n qiime2-${QIIME2_RELEASE} gevent nodejs
   rm qiime2-${QIIME2_RELEASE}-py36-linux-conda.yml
   source activate qiime2-${QIIME2_RELEASE}
   qiime dev refresh-cache

--- a/bin/02_vbox.sh
+++ b/bin/02_vbox.sh
@@ -28,7 +28,7 @@ sudo wget -O "q2studio-${QIIME2_RELEASE}.0.zip" "https://codeload.github.com/qii
 sudo unzip q2studio-${QIIME2_RELEASE}.0.zip
 sudo rm q2studio-${QIIME2_RELEASE}.0.zip
 cd q2studio-${QIIME2_RELEASE}.0
-/home/qiime2/miniconda/condabin/conda install -y -n qiime2-${QIIME2_RELEASE} gevent nodejs
+sudo /home/qiime2/miniconda/condabin/conda install -y -n qiime2-${QIIME2_RELEASE} gevent nodejs
 sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/pip install ."
 sudo /bin/bash -c "/usr/bin/env PATH=/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH npm install --unsafe-perm=true"
 sudo /bin/bash -c "/usr/bin/env PATH=/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH npm run build"

--- a/bin/02_vbox.sh
+++ b/bin/02_vbox.sh
@@ -28,10 +28,10 @@ sudo wget -O "q2studio-${QIIME2_RELEASE}.0.zip" "https://codeload.github.com/qii
 sudo unzip q2studio-${QIIME2_RELEASE}.0.zip
 sudo rm q2studio-${QIIME2_RELEASE}.0.zip
 cd q2studio-${QIIME2_RELEASE}.0
-sudo /home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/npm install
-sudo /home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/npm run build
 sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/pip install ."
 conda install -y -n qiime2-${QIIME2_RELEASE} gevent nodejs
+sudo /bin/bash -c "/usr/bin/env PATH=/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH npm install --unsafe-perm=true"
+sudo /bin/bash -c "/usr/bin/env PATH=/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH npm run build"
 sudo wget -O /usr/share/icons/hicolor/q2studio.png https://raw.githubusercontent.com/qiime2/logos/master/raster/white/qiime2-square-100.png
 
 sudo cat <<EOF > /tmp/q2studio.desktop

--- a/bin/02_vbox.sh
+++ b/bin/02_vbox.sh
@@ -28,7 +28,7 @@ sudo wget -O "q2studio-${QIIME2_RELEASE}.0.zip" "https://codeload.github.com/qii
 sudo unzip q2studio-${QIIME2_RELEASE}.0.zip
 sudo rm q2studio-${QIIME2_RELEASE}.0.zip
 cd q2studio-${QIIME2_RELEASE}.0
-conda install -y -n qiime2-${QIIME2_RELEASE} gevent nodejs
+/home/qiime2/miniconda/condabin/conda install -y -n qiime2-${QIIME2_RELEASE} gevent nodejs
 sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/pip install ."
 sudo /bin/bash -c "/usr/bin/env PATH=/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH npm install --unsafe-perm=true"
 sudo /bin/bash -c "/usr/bin/env PATH=/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH npm run build"

--- a/bin/02_vbox.sh
+++ b/bin/02_vbox.sh
@@ -28,8 +28,8 @@ sudo wget -O "q2studio-${QIIME2_RELEASE}.0.zip" "https://codeload.github.com/qii
 sudo unzip q2studio-${QIIME2_RELEASE}.0.zip
 sudo rm q2studio-${QIIME2_RELEASE}.0.zip
 cd q2studio-${QIIME2_RELEASE}.0
-sudo /home/qiime2/miniconda/envs/${QIIME2_RELEASE}/bin/npm install
-sudo /home/qiime2/miniconda/envs/${QIIME2_RELEASE}/bin/npm run build
+sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/npm install"
+sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/npm run build"
 sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/pip install ."
 sudo wget -O /usr/share/icons/hicolor/q2studio.png https://raw.githubusercontent.com/qiime2/logos/master/raster/white/qiime2-square-100.png
 

--- a/bin/02_vbox.sh
+++ b/bin/02_vbox.sh
@@ -23,16 +23,22 @@ sudo apt-get upgrade -y
 sudo apt-get install -y build-essential libgtk2.0-0 libgconf2-4
 
 # Install q2studio
-cd /opt/
-sudo wget -O "q2studio-${QIIME2_RELEASE}.0.zip" "https://codeload.github.com/qiime2/q2studio/zip/${QIIME2_RELEASE}.0"
-sudo unzip q2studio-${QIIME2_RELEASE}.0.zip
-sudo rm q2studio-${QIIME2_RELEASE}.0.zip
-cd q2studio-${QIIME2_RELEASE}.0
-sudo /home/qiime2/miniconda/condabin/conda install -y -n qiime2-${QIIME2_RELEASE} gevent nodejs
-sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/pip install ."
-sudo /bin/bash -c "/usr/bin/env PATH=/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH npm install --unsafe-perm=true"
-sudo /bin/bash -c "/usr/bin/env PATH=/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH npm run build"
-sudo wget -O /usr/share/icons/hicolor/q2studio.png https://raw.githubusercontent.com/qiime2/logos/master/raster/white/qiime2-square-100.png
+
+sudo bash QIIME2_RELEASE='${QIIME2_RELEASE}' <<'EOF'
+  # Make sure PATH contains conda and the conda-installed npm and pip
+  export PATH=/home/qiime2/miniconda/condabin:/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH
+  conda install -y -n qiime2-${QIIME2_RELEASE} gevent nodejs
+  cd /opt/
+  wget -O "q2studio-${QIIME2_RELEASE}.0.zip" "https://codeload.github.com/qiime2/q2studio/zip/${QIIME2_RELEASE}.0"
+  unzip q2studio-${QIIME2_RELEASE}.0.zip
+  rm q2studio-${QIIME2_RELEASE}.0.zip
+  cd q2studio-${QIIME2_RELEASE}.0
+  pip install .
+  # unsafe-perm is required in order for npm to write to /opt/q2studio
+  npm install --unsafe-perm=true
+  npm run build
+  wget -O /usr/share/icons/hicolor/q2studio.png https://raw.githubusercontent.com/qiime2/logos/master/raster/white/qiime2-square-100.png
+EOF
 
 sudo cat <<EOF > /tmp/q2studio.desktop
 [Desktop Entry]

--- a/bin/02_vbox.sh
+++ b/bin/02_vbox.sh
@@ -24,7 +24,7 @@ sudo apt-get install -y build-essential libgtk2.0-0 libgconf2-4
 
 # Install q2studio
 
-sudo bash QIIME2_RELEASE='${QIIME2_RELEASE}' <<'EOF'
+sudo QIIME2_RELEASE=${QIIME2_RELEASE} bash <<'EOF'
   # Make sure PATH contains conda and the conda-installed npm and pip
   export PATH=/home/qiime2/miniconda/condabin:/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH
   conda install -y -n qiime2-${QIIME2_RELEASE} gevent nodejs

--- a/bin/02_vbox.sh
+++ b/bin/02_vbox.sh
@@ -28,8 +28,8 @@ sudo wget -O "q2studio-${QIIME2_RELEASE}.0.zip" "https://codeload.github.com/qii
 sudo unzip q2studio-${QIIME2_RELEASE}.0.zip
 sudo rm q2studio-${QIIME2_RELEASE}.0.zip
 cd q2studio-${QIIME2_RELEASE}.0
-sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/npm install"
-sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/npm run build"
+sudo /home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/npm install
+sudo /home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/npm run build
 sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/pip install ."
 sudo wget -O /usr/share/icons/hicolor/q2studio.png https://raw.githubusercontent.com/qiime2/logos/master/raster/white/qiime2-square-100.png
 

--- a/bin/02_vbox.sh
+++ b/bin/02_vbox.sh
@@ -28,8 +28,8 @@ sudo wget -O "q2studio-${QIIME2_RELEASE}.0.zip" "https://codeload.github.com/qii
 sudo unzip q2studio-${QIIME2_RELEASE}.0.zip
 sudo rm q2studio-${QIIME2_RELEASE}.0.zip
 cd q2studio-${QIIME2_RELEASE}.0
-sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/pip install ."
 conda install -y -n qiime2-${QIIME2_RELEASE} gevent nodejs
+sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/pip install ."
 sudo /bin/bash -c "/usr/bin/env PATH=/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH npm install --unsafe-perm=true"
 sudo /bin/bash -c "/usr/bin/env PATH=/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin:$PATH npm run build"
 sudo wget -O /usr/share/icons/hicolor/q2studio.png https://raw.githubusercontent.com/qiime2/logos/master/raster/white/qiime2-square-100.png

--- a/bin/02_vbox.sh
+++ b/bin/02_vbox.sh
@@ -16,15 +16,11 @@ sudo rm -rf isomount $HOME/VBoxGuestAdditions.iso
 # Disable user `ubuntu` from showing up in login screen
 echo -e "[User]\nSystemAccount=true" | sudo tee /var/lib/AccountsService/users/ubuntu
 
-# Install nodejs
-curl -sL https://deb.nodesource.com/setup_7.x -o nodesource_setup.sh
-sudo bash nodesource_setup.sh
-rm nodesource_setup.sh
 # Hack to get the hosts file to update
 sudo hostnamectl set-hostname $HOSTNAME
 sudo apt-get update -y
 sudo apt-get upgrade -y
-sudo apt-get install -y nodejs npm build-essential libgtk2.0-0 libgconf2-4
+sudo apt-get install -y build-essential libgtk2.0-0 libgconf2-4
 
 # Install q2studio
 cd /opt/
@@ -32,8 +28,8 @@ sudo wget -O "q2studio-${QIIME2_RELEASE}.0.zip" "https://codeload.github.com/qii
 sudo unzip q2studio-${QIIME2_RELEASE}.0.zip
 sudo rm q2studio-${QIIME2_RELEASE}.0.zip
 cd q2studio-${QIIME2_RELEASE}.0
-sudo npm install
-sudo npm run build
+sudo /home/qiime2/miniconda/envs/${QIIME2_RELEASE}/bin/npm install
+sudo /home/qiime2/miniconda/envs/${QIIME2_RELEASE}/bin/npm run build
 sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/pip install ."
 sudo wget -O /usr/share/icons/hicolor/q2studio.png https://raw.githubusercontent.com/qiime2/logos/master/raster/white/qiime2-square-100.png
 

--- a/bin/02_vbox.sh
+++ b/bin/02_vbox.sh
@@ -31,6 +31,7 @@ cd q2studio-${QIIME2_RELEASE}.0
 sudo /home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/npm install
 sudo /home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/npm run build
 sudo su qiime2 -s /bin/bash -c "cd /opt/q2studio-${QIIME2_RELEASE}.0/;/home/qiime2/miniconda/envs/qiime2-${QIIME2_RELEASE}/bin/pip install ."
+conda install -y -n qiime2-${QIIME2_RELEASE} gevent nodejs
 sudo wget -O /usr/share/icons/hicolor/q2studio.png https://raw.githubusercontent.com/qiime2/logos/master/raster/white/qiime2-square-100.png
 
 sudo cat <<EOF > /tmp/q2studio.desktop


### PR DESCRIPTION
q2studio was not working in our VirtualBox VM as of 2021.2.  Prior to this, we discovered some new installation requirements for q2studio (see https://github.com/qiime2/docs/pull/498 and https://github.com/qiime2/docs/issues/497 for details).  This PR modifies the q2studio related portion of the VirtualBox build script so that q2studio is installed correctly.  I also tried to tidy up the q2studio installation steps.