### PR TITLE
bug: updating ami instance size to m1.large

### DIFF
--- a/packer_vars/qiime2-aws.json
+++ b/packer_vars/qiime2-aws.json
@@ -16,7 +16,7 @@
   "builders": [
     {
       "type": "amazon-ebs",
-      "instance_type": "m1.small",
+      "instance_type": "m1.large",
       "region": "us-west-2",
       "source_ami": "ami-0edf3b95e26a682df",
       "ami_name": "QIIME 2 Core - {{ user `QIIME2_RELEASE` }} ({{ timestamp }})",


### PR DESCRIPTION
aws ami was failing to be created  - the subsequent error message is shown below:
![Screen Shot 2022-06-01 at 2 37 25 PM](https://user-images.githubusercontent.com/54517601/171512155-4c30cd33-164c-4a1c-aeae-23be6125e4cf.png)

after adjusting the instance type to m1.large, the ami build was successful.
