### PR TITLE
ENH: Cut docker image size by 60%

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,8 @@ RUN conda update -q -y conda
 RUN conda install -q -y wget
 RUN apt-get install -y procps
 RUN wget https://data.qiime2.org/distro/core/qiime2-${QIIME2_RELEASE}-py38-linux-conda.yml
-RUN conda env create -n qiime2-${QIIME2_RELEASE} --file qiime2-${QIIME2_RELEASE}-py38-linux-conda.yml
+RUN conda env create -n qiime2-${QIIME2_RELEASE} --file qiime2-${QIIME2_RELEASE}-py38-linux-conda.yml \
+ && chmod -R a+rwx /opt/conda
 RUN rm qiime2-${QIIME2_RELEASE}-py38-linux-conda.yml
 RUN /bin/bash -c "source activate qiime2-${QIIME2_RELEASE}"
 RUN qiime dev refresh-cache
@@ -26,7 +27,6 @@ RUN echo "source tab-qiime" >> $HOME/.bashrc
 # Important: let any UID modify these directories so that
 # `docker run -u UID:GID` works
 RUN chmod -R a+rwx /home/qiime2
-RUN chmod -R a+rwx /opt/conda
 
 # TODO: update this to point at the new homedir defined above. Keeping this
 # for now because this will require an update to the user docs.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN conda install -q -y wget
 RUN apt-get install -y procps
 RUN wget https://data.qiime2.org/distro/core/qiime2-${QIIME2_RELEASE}-py38-linux-conda.yml
 RUN conda env create -n qiime2-${QIIME2_RELEASE} --file qiime2-${QIIME2_RELEASE}-py38-linux-conda.yml \
+ && conda clean -a -y \
  && chmod -R a+rwx /opt/conda
 RUN rm qiime2-${QIIME2_RELEASE}-py38-linux-conda.yml
 RUN /bin/bash -c "source activate qiime2-${QIIME2_RELEASE}"


### PR DESCRIPTION
## Summary

In Docker, running chmod on a file created in a previous layer causes that file to be copied to the current layer. Running `chmod -R a+rwx /opt/conda` roughly doubles the size of the image. Merging chmod into the same step as the conda install reduces the amount of space used.

This can be seen in tools like [dive](https://github.com/wagoodman/dive) or `docker history quay.io/qiime2/core:2022.8`:

```
$ docker history quay.io/qiime2/core:2022.8           
IMAGE          CREATED        CREATED BY                                      SIZE      COMMENT
7e70b34497ba   2 months ago   /bin/sh -c #(nop) WORKDIR /data                 0B        
<missing>      2 months ago   /bin/sh -c #(nop)  VOLUME [/data]               0B        
<missing>      2 months ago   |1 QIIME2_RELEASE=2022.8 /bin/sh -c chmod -R…   5.89GB    
...
```

While I was doing this, I noticed that a lot of space is used up for conda's package cache. Running `conda clean -a -y` frees up another gigabyte or two of space.

Original:

```
quay.io/qiime2/core   2022.8    7e70b34497ba   2 months ago   12.1GB
```

After merging chmod:

```
quay.io/qiime2/core   2022.8    429722143c8b   47 minutes ago   6.64GB
```

After merging chmod and running conda clean:

```
quay.io/qiime2/core   2022.8    9225241be7d9   24 minutes ago   4.74GB
```

## Related issues

#88, which originally introduced the chmod.

## Testing done

None. Sorry, very little experience with qiime.